### PR TITLE
Concurrency exercises

### DIFF
--- a/exercise/problem/requests.go
+++ b/exercise/problem/requests.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"os"
@@ -8,10 +9,11 @@ import (
 )
 
 func main() {
+	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
 	sites := []string{
-		"https://www.google.com",
+		//"https://wwsdgsdgw.google.com",
 		"https://drive.google.com",
 		"https://maps.google.com",
 		"https://hangouts.google.com",
@@ -19,13 +21,21 @@ func main() {
 	wg.Add(len(sites))
 
 	for _, site := range sites {
+		//time.Sleep(time.Millisecond * 250)
 		go func(site string) {
-			res, err := http.Get(site)
-			if err != nil {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				res, err := http.Get(site)
+				if err != nil {
+					io.WriteString(os.Stdout, "Error: "+err.Error()+"\n")
+					cancel()
+				} else {
+					io.WriteString(os.Stdout, res.Status+"\n")
+				}
 			}
-
-			io.WriteString(os.Stdout, res.Status+"\n")
-			wg.Done()
 		}(site)
 	}
 	wg.Wait()

--- a/exercise/problem/requests.go
+++ b/exercise/problem/requests.go
@@ -4,15 +4,19 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 )
 
 func main() {
+	var wg sync.WaitGroup
+
 	sites := []string{
 		"https://www.google.com",
 		"https://drive.google.com",
 		"https://maps.google.com",
 		"https://hangouts.google.com",
 	}
+	wg.Add(len(sites))
 
 	for _, site := range sites {
 		go func(site string) {
@@ -21,6 +25,8 @@ func main() {
 			}
 
 			io.WriteString(os.Stdout, res.Status+"\n")
+			wg.Done()
 		}(site)
 	}
+	wg.Wait()
 }


### PR DESCRIPTION
There are the solution for the two requested exercises.

### ⚙️ Development
This PR includes two commits, one per exercise, so you can read commit by commit in order to know how I solve each exerccies. 

* Exercise 1: I just added the sync group. I first tried adding `wg.Add(x)` in each group but I found that when the main thread `reach wg.Wait()` line before the first goroutine is executed, the execution ended before exepcted:
```
	for _, site := range sites {
		go func(site string) {
			wg.Add(1) //this line wasn't executed before the main thread reach wg.Wait()

			res, err := http.Get(site)
			if err != nil {
			}

			io.WriteString(os.Stdout, res.Status+"\n")
			wg.Done()
		}(site)
```

* Exercise 2: I used a context to control whether the HTTP call should be done or not. I found that as long a the calls are very fast, there's no advantage of stopping the calls, all HTTP calls are done before the error is notified. So would be useful to find the way to cancel active HTTP calls after the method `http.Get` is executed
