### PR TITLE
feat(ex1): add WaitGroup to sync goroutes with main thread

### DIFF
--- a/exercise/problem/requests.go
+++ b/exercise/problem/requests.go
@@ -4,9 +4,12 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 )
 
 func main() {
+	var wg sync.WaitGroup
+
 	sites := []string{
 		"https://www.google.com",
 		"https://drive.google.com",
@@ -14,8 +17,12 @@ func main() {
 		"https://hangouts.google.com",
 	}
 
+	wg.Add(len(sites)) // add as many threads as goroutes will be launch
+
 	for _, site := range sites {
 		go func(site string) {
+			defer wg.Done() // defer thread sync to waitgroup if an error occurs before normal end
+
 			res, err := http.Get(site)
 			if err != nil {
 			}
@@ -23,4 +30,6 @@ func main() {
 			io.WriteString(os.Stdout, res.Status+"\n")
 		}(site)
 	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Here is the solution for the first _concurrence_ exercise.