### PR TITLE
[SESSION 2] Add cache for greeting

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -1,0 +1,25 @@
+package main
+
+import "sync"
+
+type cache struct {
+	byName map[string]string
+	mu sync.Mutex
+}
+
+func (cache cache) FindByName(name string) (string, bool) {
+	result, ok := cache.byName[name]
+	if (!ok) {
+		return "", false
+	}
+	return result, true
+}
+
+func (cache cache) AddName(name string, result string) string {
+	cache.mu.Lock()
+	cache.byName[name] = result
+	cache.mu.Unlock()
+	return result
+}
+
+

--- a/server/cachedGreeter.go
+++ b/server/cachedGreeter.go
@@ -7,16 +7,12 @@ type cachedGreeter struct {
 	cache cache
 }
 
-func (greeter cachedGreeter) SayHi(greet greet.Greet, f func(greet.Greet) string) string {
-	cached, ok := greeter.cache.FindByName(greet.Name)
-	if !ok {
-		cached = greeter.cache.AddName(greet.Name, f(greet))
+func (greeter cachedGreeter) SayHi(f func(greet.Greet) string) func(greet2 greet.Greet) string {
+	return func (greet greet.Greet) string{
+		cached, ok := greeter.cache.FindByName(greet.Name)
+		if !ok {
+			cached = greeter.cache.AddName(greet.Name, f(greet))
+		}
+		return cached
 	}
-	return cached
-}
-
-var defaultCachedGreeter = &cachedGreeter{
-	cache: cache{
-		byName: make(map[string]string),
-	},
 }

--- a/server/cachedGreeter.go
+++ b/server/cachedGreeter.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/pabloos/http/greet"
+
+type cachedGreeter struct {
+	id    int
+	cache cache
+}
+
+func (greeter cachedGreeter) SayHi(greet greet.Greet, f func(greet.Greet) string) string {
+	cached, ok := greeter.cache.FindByName(greet.Name)
+	if !ok {
+		cached = greeter.cache.AddName(greet.Name, f(greet))
+	}
+	return cached
+}
+
+var defaultCachedGreeter = &cachedGreeter{
+	cache: cache{
+		byName: make(map[string]string),
+	},
+}

--- a/server/decorators.go
+++ b/server/decorators.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -36,5 +37,19 @@ func Delay(delay time.Duration, h http.HandlerFunc) http.HandlerFunc {
 		defer h.ServeHTTP(w, r)
 
 		time.Sleep(delay)
+	}
+}
+
+
+func Cached(h http.HandlerFunc) http.HandlerFunc {
+	var cachedGreeter = &cachedGreeter{
+		cache: cache{
+			byName: make(map[string]string),
+		},
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		cacheableRequest := r.WithContext(context.WithValue(r.Context(), "greetDecorator", cachedGreeter.SayHi))
+		h.ServeHTTP(w, cacheableRequest)
 	}
 }

--- a/server/greeter.go
+++ b/server/greeter.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"github.com/pabloos/http/greet"
+)
+
+func sayHi(greet greet.Greet) string {
+	if greet.Name == "" || greet.Location == "" {
+		return ("Tell us what is your name and where do you come from!\n")
+	}
+	return fmt.Sprintf("Hello %s, from %s\n", greet.Name, greet.Location)
+
+}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -3,10 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/pabloos/http/greet"
 	"io"
 	"net/http"
-
-	"github.com/pabloos/http/greet"
 )
 
 func index(w http.ResponseWriter, r *http.Request) {
@@ -21,11 +20,6 @@ func greetHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 400)
 		return
 	}
-
-	if t.Name == "" || t.Location == "" {
-		fmt.Fprintf(w, "Tell us what is your name and where do you come from!\n")
-		return
-	}
-
-	fmt.Fprintf(w, "Hello %s, from %s\n", t.Name, t.Location)
+	greeter := defaultCachedGreeter
+	fmt.Fprint(w, greeter.SayHi(t, sayHi))
 }

--- a/server/mux.go
+++ b/server/mux.go
@@ -9,7 +9,7 @@ func newMux() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", Debug(index))
-	mux.HandleFunc("/greet", Delay(2*time.Second, POST(greetHandler)))
+	mux.HandleFunc("/greet", Delay(2*time.Second, Cached(POST(greetHandler))))
 	// mux.HandleFunc("/greet", POST(greetHandler))
 
 	return mux

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,6 +28,14 @@ func Test_Greet(t *testing.T) {
 			Wanted: "Hello John Doe, from NY\n",
 		},
 		{
+			Name: "Cached case",
+			Greet: greet.Greet{
+				Name:     "John Doe",
+				Location: "Cached value will override this",
+			},
+			Wanted: "Hello John Doe, from NY\n",
+		},
+		{
 			Name: "void case",
 			Greet: greet.Greet{
 				Name:     "",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -31,6 +31,40 @@ func Test_Greet(t *testing.T) {
 			Name: "Cached case",
 			Greet: greet.Greet{
 				Name:     "John Doe",
+				Location: "Non cached value will override this",
+			},
+			Wanted: "Hello John Doe, from Non cached value will override this\n",
+		},
+		{
+			Name: "void case",
+			Greet: greet.Greet{
+				Name:     "",
+				Location: "",
+			},
+			Wanted: "Tell us what is your name and where do you come from!\n",
+		},
+	}
+	executeTest(t, tt, POST(greetHandler))
+}
+
+func Test_CachedGreet(t *testing.T) {
+	tt := []struct {
+		Name   string
+		Greet  greet.Greet
+		Wanted string
+	}{
+		{
+			Name: "Green case",
+			Greet: greet.Greet{
+				Name:     "John Doe",
+				Location: "NY",
+			},
+			Wanted: "Hello John Doe, from NY\n",
+		},
+		{
+			Name: "Cached case",
+			Greet: greet.Greet{
+				Name:     "John Doe",
 				Location: "Cached value will override this",
 			},
 			Wanted: "Hello John Doe, from NY\n",
@@ -45,6 +79,14 @@ func Test_Greet(t *testing.T) {
 		},
 	}
 
+	executeTest(t, tt, POST(Cached(greetHandler)))
+}
+
+func executeTest(t *testing.T, tt []struct {
+	Name   string
+	Greet  greet.Greet
+	Wanted string
+}, greetHandler http.HandlerFunc) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			buf := new(bytes.Buffer)


### PR DESCRIPTION
### 🎩 Goal

Provides a cache layer for Greeting service

### ⚙️ Development

The first iteration (first commit):

1. As long as can't cache the result of void methods avoiding logic replication, I've extracted the business logic to a function that receives a greet.Greet and return and String, then I cached this. 

`I just left the decoration in the business case layer but not at HTTP level`

The second iteration (second commit)

`I use the HTTP context in order to inject the decorator. I'm not happy with this solution as it's implemented ad hoc for greet method but it works :)`

1. Inject the greeter cache to a context method in order to decorate from the request.`It's not my favorite solution as we need to modify the decorated method to inject the decorator, but at least the decoration is done from the HTTP request layer.`

2. Add some test coverage to ensure the server is working both with and without cache.
